### PR TITLE
Fixing bind tests

### DIFF
--- a/data/bind/osfamily/Debian.yaml
+++ b/data/bind/osfamily/Debian.yaml
@@ -1,4 +1,6 @@
 ---
   bind::settings:
+    package_name: 'bind9'
+    service_name: 'bind9'
     init_file_path: '/etc/default/bind9'
     pid_file_path: '/var/run/named/named.pid'

--- a/data/bind/osfamily/RedHat.yaml
+++ b/data/bind/osfamily/RedHat.yaml
@@ -1,4 +1,9 @@
 ---
   bind::settings:
-    init_file_path: '/etc/sysconfig/bind'
-    service_name: 'bind9'
+    config_file_path: '/etc/named.conf'
+    config_dir_path: '/etc/named'
+    init_file_path: '/etc/sysconfig/named'
+    pid_file_path: '/var/run/named/named.pid'
+    service_name: 'named'
+    process_user: 'named'
+    process_group: 'named'


### PR DESCRIPTION
$ bin/test.sh bind Centos7


```
 Installing bind on Centos7
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for centos7.example42.com in environment production in 1.06 seconds
Warning: The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.
   (at /usr/share/ruby/vendor_ruby/puppet/type/package.rb:430:in `block (3 levels) in <module:Puppet>')
Info: Applying configuration version '1422197355'
Notice: /Stage[main]/Main/Tp::Install[bind]/Package[bind]/ensure: created
Notice: /Stage[main]/Main/Tp::Install[bind]/Service[named]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Main/Tp::Install[bind]/Service[named]: Unscheduling refresh on Service[named]
Notice: Finished catalog run in 13.45 seconds
Changes:
            Total: 2
Events:
          Success: 2
            Total: 2
Resources:
          Changed: 2
      Out of sync: 2
            Total: 9
Time:
         Schedule: 0.00
          Service: 0.29
   Config retrieval: 1.15
          Package: 13.08
            Total: 14.51
         Last run: 1422197370
       Filebucket: 0.00
Version:
           Config: 1422197355
           Puppet: 3.7.3
Connection to 127.0.0.1 closed.
 ```


```
$ bin/test.sh bind Debian7


Installing bind on Debian7
Warning: Setting templatedir is deprecated. See http://links.puppetlabs.com/env-settings-deprecations
   (at /usr/lib/ruby/vendor_ruby/puppet/settings.rb:1139:in `issue_deprecation_warning')
Info: Loading facts
Info: Loading facts
Info: Applying configuration version '1422197137'
Notice: /Stage[main]//Tp::Install[bind]/Package[bind9]/ensure: ensure changed 'purged' to 'present'
Info: Creating state file /var/lib/puppet/state/state.yaml
Notice: Finished catalog run in 12.83 seconds
Changes:
            Total: 1
Events:
          Success: 1
            Total: 1
Resources:
          Changed: 1
      Out of sync: 1
            Total: 9
Time:
         Schedule: 0.00
          Service: 0.03
   Config retrieval: 0.62
          Package: 12.78
            Total: 13.43
         Last run: 1422197151
       Filebucket: 0.00
Version:
           Config: 1422197137
           Puppet: 3.7.3
Connection to 127.0.0.1 closed.
```