### PR TITLE
Defaulted $repo_enabled to true to help accommodate package versioning.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -144,6 +144,7 @@ define tp::install (
       true      => true,
       'absent'  => false,
       false     => false,
+      default   => true,
     }
     tp::repo { $title:
       enabled => $repo_enabled,


### PR DESCRIPTION
If ensure was set to a version then the install would fail with the following error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: 
No matching value for selector param '1.5.0' at 
/etc/puppet/environments/elk/modules/tp/manifests/install.pp:147 on node
```
