### PR TITLE
Created Puppet3 versions of tp defines

### DIFF
--- a/manifests/concat3.pp
+++ b/manifests/concat3.pp
@@ -1,0 +1,143 @@
+#
+# = Define: tp::concat3
+#
+define tp::concat3 (
+
+  $ensure               = present,
+
+  $source               = undef,
+  $template             = undef,
+  $epp                  = undef,
+  $content              = undef,
+
+  $order                = undef,
+
+  $path                 = undef,
+  $mode                 = undef,
+  $owner                = undef,
+  $group                = undef,
+
+  $warn                 = undef,
+  $force                = undef,
+  $replace              = undef,
+  $order                = undef,
+  $ensure_newline       = undef,
+
+  $config_file_notify   = true, # If Package[$title] exists, require it
+  $config_file_require  = true, # If Service[$title] exists, notify it
+
+  $options_hash         = undef,
+
+  $debug                = false,
+  $debug_dir            = '/tmp',
+
+  $data_module          = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($debug)
+  validate_re($ensure, ['present','absent'], 'Valid values are: present, absent. WARNING: If set to absent the conf file is removed.')
+
+
+  # Settings evaluation
+  $title_elements = split($title,'::')
+  $app = $title_elements[0]
+  $fragment = $title_elements[1]
+  $settings = tp_lookup($app,'settings',$data_module,'merge')
+  $manage_path = tp_pick($path, $settings['config_file_path'])
+  $manage_content = tp_content($content, $template, $epp)
+  $manage_mode = tp_pick($mode, $settings[config_file_mode])
+  $manage_owner = tp_pick($owner, $settings[config_file_owner])
+  $manage_group = tp_pick($group, $settings[config_file_group])
+
+  # Set require if package resource is present 
+  if defined("Package[${settings[package_name]}]") {
+    $package_ref = "Package[${settings[package_name]}]"
+  } else {
+    $package_ref = undef
+  }
+  $manage_require = $config_file_require ? {
+    ''        => undef,
+    false     => undef,
+    true      => $package_ref,
+    default   => $config_file_require,
+  }
+
+  # Set notify if service resource is present 
+  if defined("Service[${settings[service_name]}]") {
+    $service_ref = "Service[${settings[service_name]}]"
+  } else {
+    $service_ref = undef
+  }
+  $manage_notify  = $config_file_notify ? {
+    ''        => undef,
+    false     => undef,
+    true      => $service_ref,
+    default   => $config_file_notify,
+  }
+
+
+  # Concat resources
+  include concat
+  
+  if !defined(Concat[$manage_path]) {
+    ::concat { $manage_path:
+      ensure         => present,
+      path           => $manage_path,
+      mode           => $manage_mode,
+      owner          => $manage_owner,
+      group          => $manage_group,
+      require        => $manage_require,
+      notify         => $manage_notify,
+      warn           => $warn,
+      force          => $force,
+      replace        => $replace,
+      ensure_newline => $ensure_newline,
+    }
+  }
+
+  ::concat::fragment { "${manage_path}_${fragment}":
+    ensure  => $ensure,
+    source  => $source,
+    content => $manage_content,
+    target  => $manage_path,
+    order   => $order,
+  }
+
+
+  # Debugging
+  if $debug == true {
+    $debug_file_params = "
+    concat { ${manage_path}:
+      ensure         => present,
+      path           => ${manage_path},
+      mode           => ${manage_mode},
+      owner          => ${manage_owner},
+      group          => ${manage_group},
+      require        => ${manage_require},
+      notify         => ${manage_notify},
+      warn           => ${warn},
+      force          => ${force},
+      replace        => ${replace},
+      ensure_newline => ${ensure_newline},
+    }
+
+    concat::fragment { \"${manage_path}_${title}\":
+      ensure         => ${ensure},
+      source         => ${source},
+      content        => ${manage_content},
+      target         => ${manage_path},
+    }
+    "
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "RESOURCE:\n${debug_file_params} \n\nSCOPE:\n${debug_scope}"
+
+    file { "tp_concat_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_concat_debug_${title}",
+    }
+  }
+
+}

--- a/manifests/conf3.pp
+++ b/manifests/conf3.pp
@@ -1,0 +1,305 @@
+# @define tp::conf3
+#
+# Note: This is a Puppet 3.x compatible version of tp::conf
+#
+# This define manages configuration files for the application named
+# in the used title..
+# It can manage the content of the managed files using different
+# methods (source, template, epp, content)
+# The actual path of the managed configuration files is determined by
+# various elements:
+# - If the path parameter is explicitly set, that's always the path used
+#
+#   tp::conf3 { 'openssh::root_config':
+#     path    => '/root/.ssh/config', # This is the path of the managed file
+#     content => template('site/openssh/root_config.erb'),
+#   }
+#
+# - If path parameter is not set and the title contains only the app
+#   name, which is the basic and most direct usage, then it's managed the
+#   *main configuration file* of the application, as defined by the variable
+#   config_file_path in the tp/data/$app directory according to the underlying OS.
+#
+#   tp::conf3 { 'openssh':  # Path is defined by tp $settings['config_file_path']
+#     template => 'site/openssh/sshd_config.erb', 
+#   }
+#
+# - When the title has a format like: app::file and no base_dir is set the path
+#   is composed using the app's *main configuration directory* and the file name
+#   used in the second part of the title (after the ::)
+#
+#   tp::conf3 { 'openssh::ssh_config': # Path is $settings['config_dir_path']/ssh_config
+#     template => 'site/openssh/ssh_config.erb',
+#   }
+#
+# - When the title has a format like: app::file it's also possible to specify,
+#   with the bas_dir parameter, the directory where to place the file:
+#
+#   tp::conf3 { 'apache::example42.com.conf':
+#     template => 'site/apache/example42.com.conf.erb',
+#     base_dir => 'conf',
+#   }
+#   Path is: $settings['conf_dir_path']/example42.com.conf
+#
+# See below for more examples.
+#
+# @example management of openssh main configuration file
+# (/etc/ssh/sshd_config) using a template
+#
+#   tp::conf3 { 'openssh':
+#     template     => 'site/openssh/sshd_config',
+#     options_hash => hiera('openssh::options_hash'), 
+#   }
+#
+#
+# @example management of openssh client file (/etc/ssh/ssh_config) using
+# a static source
+#
+#   tp::conf3 { 'openssh::ssh_config':
+#     source => 'puppet:///modules/site/openssh/ssh_config',
+#   }
+#
+# @example direct management of the content of a file
+#
+#   tp::conf3 { 'motd':
+#     content => "Welcome to ${::fqdn}\n",
+#   }
+#
+# @example management of a .conf file (configuration files placed typically
+# in directory called conf.d or *.d ). Note that here is used as $base_dir
+# 'conf' instead of the default 'config'.
+# For example with Apache on RedHat:
+# 'config' dir is '/etc/httpd'
+# 'conf' dir is '/etc/httpd/conf.d'
+# Other "common" base_dir values are 'log', 'data' but actually any value
+# can be used as long as there's a corresponding key in the TP settings data.
+#
+#   tp::conf3 { 'rsyslog::logserver':
+#     content  => "*.* @@syslog.example42.com\n",
+#     base_dir => 'conf',
+#   }
+#
+# @example management of a file related to openssh with an
+# explicit path given and the content populated via a Puppet epp template.
+# In this case the title is not used for any specific purpose, but it should
+# have a unique name and refer to the relevat app in the first part of the title (before ::) 
+#
+#   tp::conf3 { 'openssh::root_config': # Title must be unique
+#     path   => '/root/.ssh/config',
+#     epp    => 'site/openssh/root/config.epp',
+#     mode   => '0640',
+#   }
+#
+# @example when no automatic service restart is triggered by configuration file
+# changes
+#
+#   tp::conf3 { 'nginx':
+#     config_file_notify => false,
+#   }
+#
+# @example to customise notify and require dependencies
+#
+#   tp::conf3 { 'nginx::nginx_fe.conf':
+#     config_file_notify  => "Service['fe_nginx']",
+#     config_file_require => "Class['site::fe::nginx']",
+#   }
+#
+# @param ensure                    Default: present
+#   Define the status of the file: present (default value) or absent
+#
+# @param path                      Default: undef
+#   The actual path of the file to manage. When this is set, it take precedence
+#   over any other automatic paths definition.
+#
+# @param source                    Default: undef,
+#   Source of the file to use. Used in the managed file as follows:
+#   source => $source,
+#   This parameter is alternative to content, template and epp.
+#
+# @param template                  Default: undef,
+#   Erb Template to use for the content of the file. Used as follows:
+#   content => template($template),
+#   This parameter is alternative to content, source and epp.
+#
+# @param epp                       Default: undef,
+#   Epp Template to use for the content of the file. Used as follows:
+#   content => epp($epp),
+#   This parameter is alternative to content, source and template.
+#
+# @param content                   Default: undef,
+#   Content of the file. Used as follows:
+#   content => $content,
+#   This parameter is alternative to source, template and epp.
+#
+# @param base_dir                  Default: 'config',
+#   Type of the directory where to place the file, when a path is
+#   not explicitly set. This name must have a corresponding entry
+#   in TP data with a key named ${base_dir}_dir_path.
+#   The default 'config' value maps to the key config_dir_path
+#
+# @param options_hash              Default: { },
+#   Generic hash of configuration parameters specific for the app that can be
+#   used in the provided erb or epp templates respectively as @options_hash['key'] or
+#   $options_hash['key']
+#
+# @param settings_hash             Default: { }
+#   An hash that can override the application settings tp returns, according to the
+#   underlying Operating System and the default behaviour
+#
+# @param mode                      Default: undef
+#   Parameter mode for the managed file resource.
+#   By default is defined according to app and OS, the same applies for the
+#   following params.
+#
+# @param owner                     Default: undef
+#   Parameter owner for the managed file resource.
+#
+# @param group                     Default: undef
+#   Parameter group for the managed file resource.
+#
+# @param config_file_notify        Default: true
+#   By default changes in the managed file trigger a service restart of the
+#   app in the title. Set to false to avoid any restart of set the name of a Puppet
+#   resource to notify. (Ex: Service[nginx])
+#
+# @param config_file_require       Default: true,
+#   By default the file managed requires the app package, if tp::install has
+#   not been used to install the app, you may have references to an unknown
+#   resource. Set this to false to not set any dependency, or define a resource
+#   to require before managing the file (Ex: Package[apache2])
+#
+# @param debug                     Default: false,
+#   If set to true it prints debug information for tp into the directory set in
+#   debug_dir
+#
+# @param debug_dir                 Default: '/tmp',
+#   The directory where tp stoes dbug info, when enabled
+#
+# @param data_module               Default: 'tinydata'
+#   Name of the module where tp data is looked for
+#
+#
+define tp::conf3 (
+
+  $ensure               = present,
+
+  $source               = undef,
+  $template             = undef,
+  $epp                  = undef,
+  $content              = undef,
+
+  $base_dir             = 'config',
+
+  $path                 = undef,
+  $mode                 = undef,
+  $owner                = undef,
+  $group                = undef,
+
+  $config_file_notify   = true,
+  $config_file_require  = true,
+
+  $options_hash         = undef,
+  $settings_hash        = { } ,
+
+  $debug                = false,
+  $debug_dir            = '/tmp',
+
+  $data_module          = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($debug)
+  validate_re($ensure, ['present','absent'], 'Valid values are: present, absent. WARNING: If set to absent the conf file is removed.')
+
+  # Sample code for tp lookup for app specific default options 
+  # $tp_options = tp_lookup($app,'options',$data_module,'merge')
+  # $options = merge($tp_options,$options_hash)
+  $options = $options_hash
+
+  # Settings evaluation
+  $title_elements = split ($title, '::')
+  $app = $title_elements[0]
+  $file = $title_elements[1]
+  $tp_settings=tp_lookup($app,'settings',$data_module,'merge')
+  $settings=merge($tp_settings,$settings_hash)
+
+  if $file {
+    $real_dir = $settings["${base_dir}_dir_path"]
+    $auto_path = "${real_dir}/${file}"
+  } else {
+    $auto_path = $settings['config_file_path']
+  }
+  $manage_path    = tp_pick($path, $auto_path)
+  $manage_content = tp_content($content, $template, $epp)
+  $manage_mode    = tp_pick($mode, $settings[config_file_mode])
+  $manage_owner   = tp_pick($owner, $settings[config_file_owner])
+  $manage_group   = tp_pick($group, $settings[config_file_group])
+
+  # Set require if package_name is present 
+  if $settings[package_name] and $settings[package_name] != '' {
+    $package_ref = "Package[${settings[package_name]}]"
+  } else {
+    $package_ref = undef
+  }
+  $manage_require = $config_file_require ? {
+    ''        => undef,
+    false     => undef,
+    true      => $package_ref,
+    default   => $config_file_require,
+  }
+
+  # Set notify if service_name is present 
+  if $settings[service_name] and $settings[service_name] != '' {
+    $service_ref = "Service[${settings[service_name]}]"
+  } else {
+    $service_ref = undef
+  }
+  $manage_notify  = $config_file_notify ? {
+    ''        => undef,
+    false     => undef,
+    true      => $service_ref,
+    default   => $config_file_notify,
+  }
+
+
+  # Resources
+  file { $manage_path:
+    ensure  => $ensure,
+    source  => $source,
+    content => $manage_content,
+    path    => $manage_path,
+    mode    => $manage_mode,
+    owner   => $manage_owner,
+    group   => $manage_group,
+    require => $manage_require,
+    notify  => $manage_notify,
+  }
+
+
+  # Debugging
+  if $debug == true {
+    $debug_file_params = "
+    file { 'tp_conf_${manage_path}':
+      ensure  => ${ensure},
+      source  => ${source},
+      content => ${manage_content},
+      path    => ${manage_path},
+      mode    => ${manage_mode},
+      owner   => ${manage_owner},
+      group   => ${manage_group},
+      require => ${manage_require},
+      notify  => ${manage_notify},
+    }
+    "
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "RESOURCE:\n${debug_file_params} \n\nSCOPE:\n${debug_scope}"
+
+    file { "tp_conf_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_conf_debug_${title}",
+    }
+  }
+
+}

--- a/manifests/dir3.pp
+++ b/manifests/dir3.pp
@@ -1,0 +1,272 @@
+# @define tp::dir3
+#
+# Note: This is a Puppet 3.x compatible version of tp::dir
+#
+# This define manages whole directories related to the application (app)
+# set in the title.
+# If the vcsrepo parameter is set, the content of the directory is populated
+# from the url defined in the source parameter.
+# If no vcsrepo is used, the directory is manage by the native file resource.
+# The actual path of the managed directory is determined with this logic:
+# - If the path parameter is passed, that's the path used
+# - If an absolute dir path is set in the title, then it's used this path
+# - If no path is explicitly set and the title contains only the app
+#   name (ex: 'apache') then it's managed its *main* configuration directory
+#   as determined tp's data/ directory.
+# - If no path is set and the title is :: separated (ex: 'apache::conf'), then
+#   the dir path name is set by the second element set in the title.
+#   Currently supported values for dir types are:
+#    - config (default, it refers to the main configuraion directory of the app)
+#    - conf (a conf.d style directory where to place configuration fragments)
+#    - log (the logs dir, if exists)
+#    - data (where application data is stored)
+#   Planned, and TODO, support for any name for directory types
+#
+# @example management of apache main configuration directory:
+#
+#   tp::dir3 { 'apache':
+#     source => 'puppet:///modules/site/apache/role/fe',
+#   }
+#
+# @example management of apache logs directory:
+#
+#   tp::dir3 { 'apache::logs': # The logs name here is needed just to have an unique title
+#     base_dir => 'log',
+#     mode     => '0640',
+#   }
+#
+# @example management of the directory set as title, with the purge enforcement
+# that removes any local file not present on the source directory (Be careful
+# with purge ad force params, they can delete files)
+#
+#   tp::dir3 { '/data/www/default':
+#     source => 'puppet:///modules/site/apache/role/fe',
+#     purge  => true,
+#     force  => true,
+#   }
+#
+#
+# @param ensure                    Default: present
+#   Define the status of the directory: present (default value) or absent
+#
+# @param source                    Default: undef
+#   This sets the source content for the managed dir.
+#   When the vcsrepo option is set it accepts any vcs tool's supported url.
+#   For example: https://github.com/example42/puppet-tp 
+#   By default a normal directory is managed, whose content may be
+#   populated referring to a directory like: puppet:///modules/site/app/test/
+#   This would refer to the content of the directory $MODULEPATH/site/files/app/test/ 
+#
+# @param vcsrepo                   Default: undef
+#   If set the directory is managed via the vcsrepo resource.
+#   vcsrepo options are bzr, cvs, git, hg, p4, svn
+#   It requires a valid source parameter
+#
+# @param base_dir                  Default: 'config',
+#   Type of the directory to manage, when a path is not explicitly set.
+#   This name must have a corresponding entry in TP data with
+#   a key named ${base_dir}_dir_path.
+#   The default 'config' value maps to the key config_dir_path
+#
+# @param path                      Default: undef
+#   The actual path of the directory to manage.
+#   If not explicitly defined, the managed path depends on the application name
+#   set as title, the underlying OS, and the base_dir set.
+#
+# @param mode                      Default: undef
+#   Parameter mode for the managed file resource.
+#   By default is defined according to app and OS, the same applies for the
+#   following params.
+#
+# @param owner                     Default: undef
+#   Parameter owner for the managed file resource.
+#
+# @param group                     Default: undef
+#   Parameter group for the managed file resource.
+#
+# @param config_dir_notify         Default: true
+#   By default changes in the managed dir trigger a service restart of the
+#   app in the title. Set to false to avoid any restart of set the name of a Puppet
+#   resource to notify. (Ex: Service[nginx])
+
+# @param config_dir_require        Default: true,
+#   By default the resource managed requires the app package, if tp::install has
+#   not been used to install the app, you may have references to an unknown
+#   resource. Set this to false to not set any dependency, or define a resource
+#   to require before managing the dir (Ex: Package[apache2])
+#
+# @param purge                     Default: undef,
+#   Parameter purge for the managed file resource.
+#
+# @param recurse                   Default: undef,
+#   Parameter recurse for the managed file resource.
+#
+# @param settings_hash             Default: { }
+#   An hash that can override the application specific settings returned
+#   by tp according to the underlying Operating System
+#
+# @param force                     Default: undef,
+#   Parameter force for the managed file resource.
+#
+# @param debug                     Default: false,
+#   If set to true it prints debug information for tp into the directory set in
+#   debug_dir
+#
+# @param debug_dir                 Default: '/tmp',
+#   The directory where tp stores dbug info, when enabled
+#
+# @param data_module               Default: 'tinydata'
+#   Name of the module where tp data is looked for
+#
+define tp::dir3 (
+
+  $ensure               = 'present',
+
+  $source               = undef,
+  $vcsrepo              = undef,
+
+  $base_dir             = 'config',
+
+  $path                 = undef,
+  $mode                 = undef,
+  $owner                = undef,
+  $group                = undef,
+
+  $config_dir_notify    = true,
+  $config_dir_require   = true,
+
+  $purge                = undef,
+  $recurse              = undef,
+  $force                = undef,
+
+  $settings_hash        = { } ,
+
+  $debug                = false,
+  $debug_dir            = '/tmp',
+
+  $data_module          = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($debug)
+
+
+  # Settings evaluation
+  $title_elements = split ($title, '::')
+  $app = $title_elements[0]
+  $dir = $title_elements[1]
+  if $title =~ /^\/.*$/ {
+    # If title is an absolute path do a safe lookup to
+    # a dummy app
+    $tp_settings = tp_lookup('test','settings',$data_module,'merge')
+    $title_path = $title
+  } else {
+    $tp_settings = tp_lookup($app,'settings',$data_module,'merge')
+    $title_path = undef
+  }
+  $settings=merge($tp_settings,$settings_hash)
+
+  $base_dir_path = $settings["${base_dir}_dir_path"]
+
+  $manage_path    = tp_pick($path, $title_path, $base_dir_path)
+  $manage_mode    = tp_pick($mode, $settings[config_dir_mode])
+  $manage_owner   = tp_pick($owner, $settings[config_dir_owner])
+  $manage_group   = tp_pick($group, $settings[config_dir_group])
+
+  # Set require if package_name is present 
+  if $settings[package_name] and $settings[package_name] != '' {
+    $package_ref = "Package[${settings[package_name]}]"
+  } else {
+    $package_ref = undef
+  }
+  $manage_require = $config_dir_require ? {
+    ''        => undef,
+    false     => undef,
+    true      => $package_ref,
+    default   => $config_dir_require,
+  }
+
+  # Set notify if service_name is present 
+  if $settings[service_name] and $settings[package_name] != '' {
+    $service_ref = "Service[${settings[service_name]}]"
+  } else {
+    $service_ref = undef
+  }
+  $manage_notify  = $config_dir_notify ? {
+    ''        => undef,
+    false     => undef,
+    true      => $service_ref,
+    default   => $config_dir_notify,
+  }
+
+  $manage_ensure = $ensure ? {
+    'present' => $vcsrepo ? {
+      undef   => 'directory',
+      default => 'present',
+    },
+    'absent' => 'absent',
+  }
+
+  # Finally, the resources managed
+  if $vcsrepo {
+    vcsrepo { $manage_path:
+      ensure   => $manage_ensure,
+      source   => $source,
+      provider => $vcsrepo,
+      owner    => $manage_owner,
+      group    => $manage_group,
+    }
+  } else {
+    file { $manage_path:
+      ensure  => $manage_ensure,
+      source  => $source,
+      path    => $manage_path,
+      mode    => $manage_mode,
+      owner   => $manage_owner,
+      group   => $manage_group,
+      require => $manage_require,
+      notify  => $manage_notify,
+      recurse => $recurse,
+      purge   => $purge,
+      force   => $force,
+    }
+  }
+
+
+  # Debugging
+  if $debug == true {
+    $debug_file_params = "
+    vcsrepo { ${manage_path}:
+      ensure   => ${manage_ensure},
+      source   => ${source},
+      provider => ${vcsrepo},
+      owner    => ${manage_owner},
+      group    => ${manage_group},
+    }
+
+    file { ${manage_path}:
+      ensure  => ${manage_ensure},
+      source  => ${source},
+      path    => ${manage_path},
+      mode    => ${manage_mode},
+      owner   => ${manage_owner},
+      group   => ${manage_group},
+      require => ${manage_require},
+      notify  => ${manage_notify},
+      recurse => ${recurse},
+      purge   => ${purge},
+    }
+    "
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "RESOURCE:\n${debug_file_params} \n\nSCOPE:\n${debug_scope}"
+
+    file { "tp_dir_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_dir_debug_${title}",
+    }
+  }
+
+}
+

--- a/manifests/install3.pp
+++ b/manifests/install3.pp
@@ -1,0 +1,203 @@
+# @define tp::install3
+#
+# Note: This is a Puppet 3.x compatible version of tp::install
+#
+# This define installs the application (app) set in the given title.
+# It manages the packages presence and, eventually, the relevant
+# services on the supported Operating Systems.
+# Several parameters allow any kind of override of default settings and
+# customization.
+# The list of supported applications, and the relevant OS coverage is in
+# the data/ directory of the referred data_module.
+#
+# @example installation (of any any supported app and OS):
+#   tp::install3 { $app: }
+#
+# @example installation of postfix
+#   tp::install3 { 'postfix': }
+#
+# @example installation and configuration via a custom hash of tp::conf3
+# resources used to manage configuration files
+#   tp::install3 { 'puppet':
+#     conf_hash => hiera('tp::puppet::confs'),
+#   }
+#
+# @example installation with custom settings
+#   tp::install3 { 'apache':
+#     settings_hash => {
+#        package_name     => 'opt_apache',
+#        service_enable   => false,
+#        config_file_path => '/opt/apache/conf/httpd.conf',
+#        config_dir_path  => '/opt/apache/conf/',
+#      }
+#   }
+#
+# @param conf_hash                 Default: { } 
+#   An hash of tp::conf3 resources that feed a create_resources function call.
+#
+# @param dir_hash                  Default: { } 
+#   An hash of tp::dir3 resources that feed a create_resources function call.
+#
+# @param settings_hash             Default: { } 
+#   An hash that can override the application settings tp returns, according to the
+#   underlying Operating System and the default behaviour
+#
+# @param auto_repo                 Default: true
+#   Boolean to enable automatic package repo management for the specified
+#   application. Repo data is not always provided.
+#
+# @param dependency_class          Default: undef
+#   Optional name of a custom class whe you can manage depenencies
+#   required for the installation of the given application
+#
+# @param monitor_class             Default: undef
+#   Optional name of a custom class where you can manage the
+#   monitoring of this application.
+#
+# @param firewall_class            Default: undef
+#   Optional name of a custom class where you can manage the
+#   monitoring of this application.
+#
+# @param puppi_enable              Default: false
+#   Enable puppi integration. Default disabled.
+#   If set true, the puppi module is needed.
+#   
+# @param test_enable               Default: false
+#   If true, it is called the define tp::test3, which creates a script that
+#   should test the functionality of the app
+#
+# @param test_template  Default: undef
+#   Custom template to use to for the content of test script, used 
+#   by the tp::test3 define. It requires test_enable = true
+#
+# @param debug                     Default: false,
+#   If set to true it prints debug information for tp into the directory set in
+#   debug_dir
+#
+# @param debug_dir                 Default: '/tmp',
+#   The directory where tp stores dbug info, when enabled
+#
+# @param data_module               Default: 'tinydata'
+#   Name of the module where tp data is looked for
+#
+define tp::install3 (
+
+  $conf_hash                 = { } ,
+  $dir_hash                  = { } ,
+
+  $settings_hash             = { } ,
+
+  $auto_repo                 = true,
+
+  $dependency_class          = undef,
+  $monitor_class             = undef,
+  $firewall_class            = undef,
+
+  $puppi_enable              = false,
+
+  $test_enable               = false,
+  $test_template             = undef,
+
+  $debug                     = false,
+  $debug_dir                 = '/tmp',
+
+  $data_module               = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($auto_repo)
+  validate_bool($puppi_enable)
+  validate_bool($debug)
+  validate_hash($conf_hash)
+  validate_hash($dir_hash)
+  validate_hash($settings_hash)
+
+
+  # Settings evaluation
+  $tp_settings=tp_lookup($title,'settings',$data_module,'merge')
+  $settings=merge($tp_settings,$settings_hash)
+  $service_require = $settings[package_name] ? {
+    ''      => undef,
+    undef   => undef,
+    default => Package[$settings[package_name]],
+  }
+  $service_ensure = $settings[service_ensure]
+  $service_enable = $settings[service_enable]
+
+  # Dependency class
+  if $dependency_class and $dependency_class != '' {
+    include $dependency_class
+  }
+
+
+  # Automatic repo management
+  if $auto_repo == true
+  and $settings[repo_url] {
+    tp::repo3 { $title:
+      enabled => true,
+      before  => Package[$settings[package_name]],
+    }
+  }
+
+
+  # Resources
+  if $settings[package_name] {
+    ensure_resource( 'package', $settings[package_name], {
+      'ensure' => 'present',
+    } )
+  }
+
+  if $settings[service_name] {
+    ensure_resource( 'service', $settings[service_name], {
+      'ensure'  => $service_ensure,
+      'enable'  => $service_enable,
+      'require' => $service_require,
+    } )
+  }
+
+  if $conf_hash != {} {
+    create_resources('tp::conf3', $conf_hash )
+  }
+  if $dir_hash != {} {
+    create_resources('tp::dir3', $dir_hash )
+  }
+
+
+  # Optional puppi integration 
+  if $puppi_enable == true {
+    tp::puppi3 { $title:
+      settings_hash => $settings,
+    }
+  }
+
+  # Test script creation (use to test, check, monitor the app)
+  if $test_enable == true {
+    tp::test3 { $title:
+      settings_hash => $settings,
+      template      => $test_template,
+    }
+  }
+
+  # Extra classes
+  if $monitor_class and $monitor_class != '' {
+    include $monitor_class
+  }
+  if $firewall_class and $firewall_class != '' {
+    include $firewall_class
+  }
+
+  # Debugging
+  if $debug == true {
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "SCOPE:\n${debug_scope}"
+
+    file { "tp_install_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_install_debug_${title}",
+    }
+  }
+
+
+}

--- a/manifests/puppi3.pp
+++ b/manifests/puppi3.pp
@@ -1,0 +1,159 @@
+#
+#
+# = Define: tp::puppi3
+#
+# Manages Puppi integration
+# Usage of this define is optional.
+# When used, it requires Puppi.
+# 
+# == Parameters
+#
+define tp::puppi3 (
+
+  $ensure         = present,
+
+  $check_enable   = true ,
+  $check_template = 'tp/puppi/check.erb',
+
+  $info_enable    = true ,
+  $info_template  = 'tp/puppi/info.erb',
+  $info_defaults  = true,
+
+  $log_enable     = true ,
+
+  $options_hash   = { },
+  $settings_hash  = { },
+
+  $data_module    = 'tinydata',
+
+  $verbose        = false,
+
+  ) {
+
+  # If we use tp::puppi3 we need puppi
+  include puppi
+
+  # Parameters validation
+  validate_bool($check_enable)
+  validate_bool($info_enable)
+  validate_bool($info_defaults)
+  validate_bool($log_enable)
+  validate_bool($verbose)
+  validate_hash($options_hash)
+  validate_hash($settings_hash)
+
+
+  # Settings evaluation
+  $tp_settings=tp_lookup($title,'settings',$data_module,'merge')
+  $settings=merge($tp_settings,$settings_hash)
+
+  # Default options and computed variables
+  $puppi_defaults = {
+    check_timeout          => '10',
+
+    check_process_command  => 'check_procs',
+    check_process_critical => '1:',
+    check_process_warning  => '1:',
+    check_process_metric   => 'PROCS',
+
+    check_service_command  => 'service',
+
+    check_port_command     => 'check_tcp',
+    check_port_critical    => '10',
+    check_port_warning     => '5',
+    check_port_host        => '127.0.0.1',
+  }
+
+  $puppi_options = merge($puppi_defaults, $options_hash)
+
+  $real_check_base_dir = pick($puppi_options[check_command_base_dir],$::puppi::checkpluginsdir)
+
+  $real_check_process_command = $puppi_options[check_process_command] ? {
+    'check_procs' => "${real_check_base_dir}/${puppi_options[check_process_command]} \
+       -c ${puppi_options[check_process_critical]} \
+       -w ${puppi_options[check_process_warning]} \
+       -m ${puppi_options[check_process_metric]} \
+       -C ${settings[process_name]} \
+      ",
+    default       => "${real_check_base_dir}/${puppi_options[check_process_command]}",
+  }
+
+  $real_check_service_command = $puppi_options[check_service_command] ? {
+    'service' => "service ${settings[service_name]} status",
+    default   => $puppi_options[check_service_command],
+  }
+
+  $real_check_port_command = $puppi_options[check_port_command] ? {
+    'check_tcp' => "${real_check_base_dir}/${puppi_options[check_port_command]} \
+       -H ${puppi_options[check_port_host]} \
+       -c ${puppi_options[check_port_critical]} \
+       -w ${puppi_options[check_port_warning]} \
+       -p ${settings[tcp_port]} \
+     ",
+    default     => "${real_check_base_dir}/${puppi_options[check_port_command]}",
+  }
+
+  $array_package_name=any2array($settings['package_name'])
+  $array_service_name=any2array($settings['service_name'])
+  $array_log_file_path=any2array($settings['log_file_path'])
+  $array_tcp_port=any2array($settings['tcp_port'])
+  $array_info_commands=any2array($settings['info_commands'])
+
+  # Puppi checks
+  if $check_enable == true {
+    file { "${::puppi::params::checksdir}/${title}":
+      ensure  => $ensure,
+      mode    => '0755',
+      owner   => $::puppi::params::configfile_owner,
+      group   => $::puppi::params::configfile_group,
+      require => Class['puppi'],
+      content => template($check_template),
+      tag     => 'tp_puppi_check',
+    }
+  }
+
+
+  # Puppi info
+  if $info_enable == true {
+    if $info_defaults == true {
+      file { "${::puppi::params::infodir}/${title}":
+        ensure  => $ensure,
+        mode    => '0750',
+        owner   => $::puppi::params::configfile_owner,
+        group   => $::puppi::params::configfile_group,
+        require => Class['puppi'],
+        content => template($info_template),
+        tag     => 'tp_puppi_info',
+      }
+    }
+
+    if $settings[info_commands] {
+      $infos = any2array($settings[info_commands])
+      file { "${::puppi::params::infodir}/${title}_extra":
+        ensure  => $ensure,
+        mode    => '0750',
+        owner   => $::puppi::params::configfile_owner,
+        group   => $::puppi::params::configfile_group,
+        require => Class['puppi'],
+        content => inline_template('<% @infos.each do |cmd| %><%= cmd %><% end %>'),
+        tag     => 'tp_puppi_info',
+      }
+    }
+  }
+
+
+  # Puppi log
+  if $log_enable == true {
+    $logs = any2array($settings[log_file_path])
+    file { "${::puppi::params::logsdir}/${title}":
+      ensure  => $ensure,
+      mode    => '0750',
+      owner   => $::puppi::params::configfile_owner,
+      group   => $::puppi::params::configfile_group,
+      require => Class['puppi'],
+      content => inline_template('<% @logs.each do |path| %><%= path %><% end %>'),
+      tag     => 'tp_puppi_log',
+    }
+  }
+
+}

--- a/manifests/repo3.pp
+++ b/manifests/repo3.pp
@@ -1,0 +1,188 @@
+#
+# Define tp::repo3
+#
+# Manages a yum/apt repo for an application
+#
+define tp::repo3 (
+
+  $enabled             = true,
+
+  $description         = "${title} repository",
+
+  $repo_url            = undef,
+  $key_url             = undef,
+  $key                 = undef,
+
+  $yum_priority        = undef,
+  $yum_gpgcheck        = undef,
+  $yum_mirrorlist      = undef,
+
+  $apt_key_server      = undef,
+  $apt_key_fingerprint = undef,
+  $apt_release         = undef,
+  $apt_repos           = undef,
+  $apt_release         = undef,
+  $apt_pin             = undef,
+  $apt_include_src     = false,
+
+  $debug               = false,
+  $debug_dir           = '/tmp',
+
+  $data_module         = 'tinydata',
+
+) {
+
+  # Parameters validation
+  validate_bool($enabled)
+  validate_bool($debug)
+
+
+  # Settings evaluation
+  $enabled_num = bool2num($enabled)
+  $ensure      = bool2ensure($enabled)
+  $tp_settings = tp_lookup($title,'settings',$data_module,'merge')
+  $user_settings = {
+    repo_url            => $repo_url,
+    key_url             => $key_url,
+    key                 => $key,
+    apt_key_server      => $apt_key_server,
+    apt_key_fingerprint => $apt_key_fingerprint,
+    apt_release         => $apt_release,
+    yum_priority        => $yum_priority,
+    yum_mirrorlist      => $yum_mirrorlist,
+    apt_repos           => $apt_repos,
+    apt_release         => $apt_release,
+    apt_include_src     => $apt_include_src,
+    apt_pin             => $apt_pin,
+  }
+  $user_settings_clean = delete_undef_values($user_settings)
+  $settings = merge($tp_settings,$user_settings_clean)
+
+  $manage_yum_gpgcheck = $yum_gpgcheck ? {
+    undef   => $settings[key_url] ? {
+      undef   => '0',
+      default => '1',
+    },
+    default => $yum_gpgcheck,
+  }
+
+
+  # Resources
+  case $::osfamily {
+    'RedHat': {
+      if !defined(Yumrepo[$title]) {
+        yumrepo { $title:
+          enabled    => $enabled_num,
+          descr      => $description,
+          baseurl    => $settings[repo_url],
+          gpgcheck   => $manage_yum_gpgcheck,
+          gpgkey     => $settings[key_url],
+          priority   => $settings[yum_priority],
+          mirrorlist => $settings[yum_mirrorlist],
+        }
+      }
+    }
+    # To avoid to introduce another dependency we manage apt repos directly
+    'Debian': {
+      if !defined(Exec['tp_apt_update'])
+      and is_string($settings[package_name])
+      and $settings[package_name] != ''
+      and $settings[package_name] != undef
+      and is_string($settings[key]) {
+        exec { 'tp_apt_update':
+          command     => '/usr/bin/apt-get -qq update',
+          path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+          logoutput   => false,
+          refreshonly => true,
+        }
+      }
+
+      if is_string($settings[package_name])
+      and $settings[package_name] != ''
+      and $settings[package_name] != undef
+      and is_string($settings[key]) {
+        Exec['tp_apt_update'] -> Package[$settings[package_name]]
+      }
+
+      if !defined(File["${title}.list"])
+      and !empty($settings[key]) {
+        file { "${title}.list":
+          ensure  => $ensure,
+          path    => "/etc/apt/sources.list.d/${title}.list",
+          owner   => root,
+          group   => root,
+          mode    => '0644',
+          content => template('tp/apt/source.list.erb'),
+          notify  => Exec['tp_apt_update'],
+        }
+      }
+
+      if !defined(Exec["tp_aptkey_add_${settings[key]}"])
+      and !empty($settings[key])
+      and !empty($settings[key_url]) {
+        exec { "tp_aptkey_add_${settings[key]}":
+          command => "wget -O - ${settings[key_url]} | apt-key add -",
+          unless  => "apt-key list | grep -q ${settings[key]}",
+          path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+          before  => File["${title}.list"],
+          user    => 'root',
+        }
+      }
+
+      if !defined(Exec["tp_aptkey_adv_${settings[key]}"])
+      and !empty($settings[key])
+      and !empty($settings[apt_key_server]) {
+        exec { "tp_aptkey_adv_${settings[key]}":
+          command => "apt-key adv --keyserver ${settings[apt_key_server]} --recv ${settings[apt_key_fingerprint]}",
+          unless  => "apt-key list | grep -q ${settings[key]}",
+          path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+          before  => File["${title}.list"],
+          user    => 'root',
+        }
+      }
+
+    }
+    default: {
+      notify { "No repo for ${title}":
+        message =>"No dedicated repo available for ${::osfamily}",
+      }
+    }
+  }
+
+
+  # Debugging
+  if $debug == true {
+
+    $debug_file_params = "
+      yumrepo { ${title}:
+        enabled        => ${enabled_num},
+        descr          => ${description},
+        baseurl        => ${settings[repo_url]},
+        gpgcheck       => ${manage_yum_gpgcheck},
+        gpgkey         => ${settings[key_url]},
+        priority       => ${settings[yum_priority]},
+      }
+
+      apt::source { ${title}:
+        ensure     => ${ensure},
+        comment    => ${description},
+        location   => ${settings[repo_url]},
+        key        => ${settings[key]},
+        key_source => ${settings[key_url]},
+        key_server => ${settings[apt_key_server]},
+        repos      => ${settings[apt_repos]},
+        release    => ${settings[apt_release]},
+        pin        => ${settings[apt_pin]},
+      }
+    "
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "RESOURCE:\n${debug_file_params} \n\nSCOPE:\n${debug_scope}"
+
+    file { "tp_repo_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_repo_debug_${title}",
+    }
+  }
+
+}

--- a/manifests/stdmod3.pp
+++ b/manifests/stdmod3.pp
@@ -1,0 +1,211 @@
+#
+# = Define: tp::stdmod3
+#
+# This defines reproduces a standard module based
+# on a this stdmod standard template
+# (https://github.com/stdmod/puppet-skeleton-standard)
+#
+# The define exposes stdmod compliant parameters for
+# standard package, service, configuration setups.
+#
+define tp::stdmod3 (
+
+  $package_name              = undef,
+  $package_ensure            = 'present',
+
+  $service_name              = undef,
+  $service_ensure            = undef,
+  $service_enable            = undef,
+
+  $config_file_path          = undef,
+  $config_file_replace       = undef,
+  $config_file_require       = undef,
+  $config_file_notify        = 'default',
+  $config_file_source        = undef,
+  $config_file_template      = undef,
+  $config_file_epp           = undef,
+  $config_file_content       = undef,
+  $config_file_options_hash  = undef,
+  $config_file_owner         = undef,
+  $config_file_group         = undef,
+  $config_file_mode          = undef,
+
+  $config_dir_path           = undef,
+  $config_dir_source         = undef,
+  $config_dir_purge          = undef,
+  $config_dir_force          = undef,
+  $config_dir_recurse        = undef,
+
+  $dependency_class          = undef,
+  $monitor_class             = undef,
+  $firewall_class            = undef,
+
+  $debug                     = false,
+  $debug_dir                 = '/tmp',
+
+  $data_module               = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($debug)
+  
+
+  # Settings evaluation
+  $tp_settings = tp_lookup($title,'settings',$data_module,'merge')
+  $user_settings = {
+    package_name              => $package_name,
+    package_ensure            => $package_ensure,
+    service_name              => $service_name,
+    service_ensure            => $service_ensure,
+    service_enable            => $service_enable,
+    config_file_path          => $config_file_path,
+    config_file_replace       => $config_file_replace,
+    config_file_require       => $config_file_require,
+    config_file_notify        => $config_file_notify,
+    config_file_owner         => $config_file_owner,
+    config_file_group         => $config_file_group,
+    config_file_mode          => $config_file_mode,
+    config_dir_path           => $config_dir_path,
+    config_dir_purge          => $config_dir_purge,
+    config_dir_force          => $config_dir_force,
+    config_dir_recurse        => $config_dir_recurse,
+  }
+  $user_settings_clean = delete_undef_values($user_settings)
+  $settings = merge($tp_settings,$user_settings_clean)
+
+  $manage_config_file_content = tp_content($config_file_content, $config_file_template, $config_file_epp)
+  $manage_config_file_require = "Package[${settings[package_name]}]"
+  $manage_config_file_notify  = $config_file_notify ? {
+    'default' => "Service[${settings[service_name]}]",
+    'undef'   => undef,
+    ''        => undef,
+    default   => $config_file_notify,
+  }
+
+  if $package_ensure == 'absent' {
+    $manage_service_enable = undef
+    $manage_service_ensure = stopped
+    $config_dir_ensure = absent
+    $config_file_ensure = absent
+  } else {
+    $manage_service_enable = $service_enable ? {
+      ''      => undef,
+      'undef' => undef,
+      default => $service_enable,
+    }
+    $manage_service_ensure = $service_ensure ? {
+      ''      => undef,
+      'undef' => undef,
+      default => $service_ensure,
+    }
+    $config_dir_ensure = directory
+    $config_file_ensure = present
+  }
+
+
+  # Dependency class
+  if $dependency_class and $dependency_class != '' {
+    include $dependency_class
+  }
+
+
+  # Resources
+  if $settings[package_name] {
+    package { $settings[package_name]:
+      ensure => $settings[package_ensure],
+    }
+  }
+
+  if $settings[service_name] {
+    service { $settings[service_name]:
+      ensure => $settings[service_ensure],
+      enable => $settings[service_enable],
+    }
+  }
+
+  if $config_file_source
+  or $manage_config_file_content
+  or $config_file_ensure == 'absent' {
+    file { $settings[config_file_path]:
+      ensure  => $config_file_ensure,
+      path    => $settings[config_file_path],
+      mode    => $settings[config_file_mode],
+      owner   => $settings[config_file_owner],
+      group   => $settings[config_file_group],
+      source  => $settings[config_file_source],
+      content => $manage_config_file_content,
+      notify  => $manage_config_file_notify,
+      require => $manage_config_file_require,
+    }
+  }
+
+  if $config_dir_source {
+    file { $settings[config_dir_path]:
+      ensure  => $config_dir_ensure,
+      path    => $settings[config_dir_path],
+      source  => $config_dir_source,
+      recurse => $settings[config_dir_recurse],
+      purge   => $settings[config_dir_purge],
+      force   => $settings[config_dir_force],
+      notify  => $manage_config_file_notify,
+      require => $manage_config_file_require,
+    }
+  }
+
+
+  # Extra classes
+  if $monitor_class and $monitor_class != '' {
+    include $monitor_class
+  }
+  if $firewall_class and $firewall_class != '' {
+    include $firewall_class
+  }
+
+
+  # Debugging
+  if $debug == true {
+    $debug_file_params = "
+    package { ${settings[package_name]}:
+      ensure => ${settings[package_ensure]},
+    }
+
+    service { ${settings[service_name]}:
+      ensure => ${settings[service_ensure]},
+      enable => ${settings[service_enable]},
+    } 
+
+    file { ${settings[config_file_path]}:
+      ensure  => ${config_file_ensure},
+      path    => ${settings[config_file_path]},
+      mode    => ${settings[config_file_mode]},
+      owner   => ${settings[config_file_owner]},
+      group   => ${settings[config_file_group]},
+      source  => ${settings[config_file_source]},
+      content => ${manage_config_file_content},
+      notify  => ${manage_config_file_notify},
+      require => ${manage_config_file_require},
+    }
+
+    file { ${settings[config_dir_path]}:
+      ensure  => ${config_dir_ensure},
+      path    => ${settings[config_dir_path]},
+      source  => ${config_dir_source},
+      recurse => ${settings[config_dir_recurse]},
+      purge   => ${settings[config_dir_purge]},
+      force   => ${settings[config_dir_force]},
+      notify  => ${manage_config_file_notify},
+      require => ${manage_config_file_require},
+    }
+    "
+    $debug_scope = inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*)/ } %>')
+    $manage_debug_content = "RESOURCE:\n${debug_file_params} \n\nSCOPE:\n${debug_scope}"
+
+    file { "tp_stdmod_debug_${title}":
+      ensure  => present,
+      content => $manage_debug_content,
+      path    => "${debug_dir}/tp_stdmod_debug_${title}",
+    }
+  }
+
+}

--- a/manifests/test3.pp
+++ b/manifests/test3.pp
@@ -1,0 +1,85 @@
+#
+# = Define: tp::test3
+#
+# Note: This is a Puppet 3.x compatible version of tp::test
+#
+# It creates test scripts to be executed in whatever way
+# 
+# == Parameters
+#
+define tp::test3 (
+
+  $ensure              = present,
+
+  $template            = 'tp/test/acceptance.erb',
+
+  $options_hash        = { },
+  $settings_hash       = { },
+
+  $data_module         = 'tinydata',
+  $base_dir            = '/etc/tp/test',
+
+  $verbose             = false,
+
+  ) {
+
+  # Parameters validation
+  validate_bool($verbose)
+  validate_hash($options_hash)
+  validate_hash($settings_hash)
+
+
+  # Settings evaluation
+  $tp_settings=tp_lookup($title,'settings',$data_module,'merge')
+  $settings=merge($tp_settings,$settings_hash)
+
+  # Default options and computed variables
+  $options_defaults = {
+    check_timeout          => '10',
+    check_service_command  => "service ${settings[service_name]} status",
+    check_package_command  => $::osfamily ? {
+      'RedHat' => "rpm -q ${settings[package_name]}",
+      'Debian' => "dpkg -l ${settings[package_name]}",
+      default  => "puppet resource package ${settings[package_name]}"
+    },
+    check_port_command     => 'check_tcp',
+    check_port_critical    => '10',
+    check_port_warning     => '5',
+    check_port_host        => '127.0.0.1',
+  }
+
+  $options = merge($options_defaults, $options_hash)
+
+  $array_package_name=any2array($settings['package_name'])
+  $array_service_name=any2array($settings['service_name'])
+  $array_tcp_port=any2array($settings['tcp_port'])
+
+  # TODO: Refine
+  if ! defined('/etc/tp') {
+    file { '/etc/tp/':
+      ensure => directory,
+      mode   => '0755',
+      owner  => root,
+      group  => root,
+    }
+  }
+
+  if ! defined(File[$base_dir]) {
+    file { $base_dir:
+      ensure => directory,
+      mode   => '0755',
+      owner  => root,
+      group  => root,
+    }
+  }
+
+  file { "${base_dir}/${title}":
+    ensure  => $ensure,
+    mode    => '0755',
+    owner   => root,
+    group   => root,
+    content => template($template),
+    tag     => 'tp_test',
+  }
+
+}

--- a/manifests/uninstall3.pp
+++ b/manifests/uninstall3.pp
@@ -1,0 +1,87 @@
+# @define tp::uninstall3
+#
+# This define uninstalls an application (app) set in the given title.
+#
+# @example removal (of any any supported app and OS):
+#   tp::uninstall3 { $app: }
+#
+# @example remove also configuration file(s) and dirs (DANGER ZONE!)
+#   tp::uninstall3 { 'postfix':
+#     conf_hash => $postfix_files,
+#     dir_hash  => $postfix_dirs,
+#   }
+#
+# @param conf_hash                 Default: { } 
+#   An hash of tp::conf3 resources to remove.
+#   with ensure absent.
+#
+# @param dir_hash                  Default: { } 
+#   An hash of tp::dir3 resources to remove.
+#
+# @param settings_hash             Default: { } 
+#   An hash that can override the application settings tp returns, according to the
+#   underlying Operating System and the default behaviour
+#
+# @param auto_repo                 Default: true
+#   Boolean to enable automatic package repo management for the specified
+#   application. Repo data is not always provided.
+#
+# @param data_module               Default: 'tinydata'
+#   Name of the module where tp data is looked for
+#
+define tp::uninstall3 (
+
+  $conf_hash                 = { } ,
+  $dir_hash                  = { } ,
+
+  $settings_hash             = { } ,
+
+  $auto_repo                 = true,
+
+  $data_module               = 'tinydata',
+
+  ) {
+
+  # Parameters validation
+  validate_bool($auto_repo)
+  validate_hash($conf_hash)
+  validate_hash($dir_hash)
+  validate_hash($settings_hash)
+
+
+  # Settings evaluation
+  $tp_settings=tp_lookup($title,'settings',$data_module,'merge')
+  $settings=merge($tp_settings,$settings_hash)
+
+  # Automatic repo management
+  if $auto_repo == true
+  and $settings[repo_url] {
+    tp::repo3 { $title:
+      enabled => false,
+      before  => Package[$settings[package_name]],
+    }
+  }
+
+
+  # Resources
+  if $settings[package_name] {
+    ensure_resource( 'package', $settings[package_name], {
+      'ensure' => 'absent',
+    } )
+  }
+
+  if $settings[service_name] {
+    ensure_resource( 'service', $settings[service_name], {
+      'ensure'  => 'stopped',
+      'enable'  => false,
+    } )
+  }
+
+  if $conf_hash != {} {
+    create_resources('tp::conf3', $conf_hash , { ensure => absent })
+  }
+  if $dir_hash != {} {
+    create_resources('tp::dir3', $dir_hash , { ensure => absent })
+  }
+
+}


### PR DESCRIPTION
Here are the preliminary Puppet3 versions of tp defines
They are anticipated here to ease migration of current code when
executed in a Puppet3 environment.
