### PR TITLE
Make the main service and package available under the application's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,19 @@ If, for whatever reason, you don't want to automatically manage a repository for
     }
 
 
+### Custom Dependencies
+
+In rare cases it might be necessary to have a relationship in between the parts of a `tp::install`. To allow this, the main package and service resource are available under the name of the application:
+
+```
+tp::install { exim: }
+
+Package[exim] -> Exec['extra setup script'] ~> Service[exim]
+```
+
+This works even if, like in this case, the package and service names vary widely across distributions.
+
+
 ## Usage with Hiera
 
 You may find useful the ```create_resources``` defines that are feed, in the main ```tp``` class by special ```hiera_hash``` lookups that map all the available ```tp``` defines to hiera keys in this format ```tp::<define>_hash```.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -106,7 +106,7 @@ define tp::install (
   if $settings[package_name] == Variant[Undef,String[0]] {
     $service_require = undef
   } else {
-    $service_require = Package[$settings[package_name]]
+    $service_require = Package[$name]
   }
 
   $service_ensure = $ensure ? {
@@ -139,8 +139,16 @@ define tp::install (
   if $settings[package_name] {
     $packages_array=any2array($settings[package_name])
     $packages_array.each |$pkg| {
-      package { $pkg:
-        ensure => $ensure,
+      # Setup a stable alias to the application's name for the "main" package
+      if $pkg != $name and (size($packages_array) == 1 or $svc == $settings[main_package])  {
+        package { $name:
+          name   => $pkg,
+          ensure => $ensure,
+        }
+      } else {
+        package { $pkg:
+          ensure => $ensure,
+        }
       }
     }
   }
@@ -148,10 +156,20 @@ define tp::install (
   if $settings[service_name] {
     $services_array=any2array($settings[service_name])
     $services_array.each |$svc| {
-      service { $svc:
-        ensure  => $service_ensure,
-        enable  => $service_enable,
-        require => $service_require,
+      # Setup a stable alias to the application's name for the "main" service
+      if $svc != $name and (size($services_array) == 1 or $svc == $settings[main_service])  {
+        service { $name:
+          name    => $svc,
+          ensure  => $service_ensure,
+          enable  => $service_enable,
+          require => $service_require,
+        }
+      } else {
+        service { $svc:
+          ensure  => $service_ensure,
+          enable  => $service_enable,
+          require => $service_require,
+        }
       }
     }
   }


### PR DESCRIPTION
This allows the following usage:

```
tp::install { exim: }

Package[exim] -> File['extra conf'] ~> Service[exim]
```

without having to know anything about the underlying OS and data, when
tp::conf and tp::dir do not suffice.
