### PR TITLE
Fixes #44 - install_hash should support arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,24 @@
 # CHANGELOG
 
+## Unreleased
+
+* Fixes #44 - install_hash should support arrays [@logicminds]
+
 ## 2.1.0
 
 * Added validate_syntax option to tp::conf
 
 ## 2.0.4
+
 * Added task tp::test
 
 ## 2.0.1
+
 * Added more spec tests
 * Minor fixes
 
 ## 2.0.0
+
 * Removed Puppet3 defines
 * Class tp: Removed params: packages, services, files
 * Define tp::install: Params auto_prerequisites renamed to auto_prereq

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,10 +15,8 @@ class tp (
   String $check_package_command      = $::tp::params::check_package_command,
   String $tp_dir                     = $::tp::params::tp_dir,
   String $ruby_path                  = $::tp::params::ruby_path,
-
   Hash $options_hash                 = {},
-
-  Hash $install_hash                 = {},
+  Variant[Hash,Array[String]] $install_hash = {},
   Hash $conf_hash                    = {},
   Hash $dir_hash                     = {},
   Hash $concat_hash                  = {},
@@ -54,10 +52,10 @@ class tp (
     content => template('tp/tp.erb'),
   }
 
-  if $install_hash != {} {
-    $install_hash.each |$k,$v| {
-      tp_install($k,$v)
-    }
+  if $install_hash =~ Array {
+    $install_hash.each | $name| { tp_install($name, {ensure => present}) }
+  } else {
+    $install_hash.each | $name, $options| { tp_install($name, $options) }
   }
   if $conf_hash != {} {
     $conf_hash.each |$k,$v| {

--- a/spec/classes/tp_spec.rb
+++ b/spec/classes/tp_spec.rb
@@ -11,26 +11,57 @@ describe 'tp' do
         it { should have_resource_count(4) }
       end
 
+      context 'when install_hash is an array' do
+        let(:params) do
+          {
+            tp_dir: '/opt/tp',
+            tp_owner: 'al',
+            tp_group: 'al',
+            tp_path: '/usr/bin/tp',
+            install_hash: %w[openssh sysdig]
+          }
+        end
+
+        it { is_expected.to contain_tp__install('openssh') }
+        it { is_expected.to contain_tp__install('sysdig') }
+      end
+
+      context 'when install_hash is a hash' do
+        let(:params) do
+          {
+            tp_dir: '/opt/tp',
+            tp_owner: 'al',
+            tp_group: 'al',
+            tp_path: '/usr/bin/tp',
+            install_hash: { 'openssh' => { 'ensure' => 'present' }, 'sysdig' => { 'ensure' => 'present' } }
+          }
+        end
+        it { is_expected.to contain_tp__install('openssh') }
+        it { is_expected.to contain_tp__install('sysdig') }
+      end
+
       context 'with custom tp_dir => /opt/tp, tp_owner =al, tp_group => al, tp_path => /usr/bin/tp' do
-        let(:params) do {
-          'tp_dir'   => '/opt/tp',
-          'tp_owner' => 'al',
-          'tp_group' => 'al',
-          'tp_path'  => '/usr/bin/tp',
-        } end
+        let(:params) do
+          {
+            'tp_dir' => '/opt/tp',
+            'tp_owner' => 'al',
+            'tp_group' => 'al',
+            'tp_path'  => '/usr/bin/tp'
+          }
+        end
 
         dir_params = {
           'ensure' => 'directory',
           'mode'   => '0755',
           'owner'  => 'al',
-          'group'  => 'al',
+          'group'  => 'al'
         }
         file_params = {
           'ensure' => 'present',
           'mode'   => '0755',
           'owner'  => 'al',
           'group'  => 'al',
-          'path'   => '/usr/bin/tp',
+          'path'   => '/usr/bin/tp'
         }
         it { is_expected.to contain_file('/opt/tp').only_with(dir_params) }
         it { is_expected.to contain_file('/usr/bin/tp').with(file_params) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ if File.exist?(default_module_facts_path) && File.readable?(default_module_facts
   default_facts.merge!(YAML.safe_load(File.read(default_module_facts_path)))
 end
 
+at_exit { RSpec::Puppet::Coverage.report! }
+
+
 RSpec.configure do |c|
   c.default_facts = default_facts
 end


### PR DESCRIPTION
  * previously when setting install_hash from hiera or as a parameter
    you could only use hashes.  This fix allows one to pass an array of
    apps to install instead of just a hash.  While the parameter name
    contains the word hash, it will now permit a array and take defaults
    to install.  When using an array be aware that ensure=present will
    be default and cannot be modifed.  If you need to change this pass
    a hash instead like before.

