### PR TITLE
Make tp install anything, even when no hieradata is present. Requires…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 2.3.0
+* Do not fail on missing tinydata, try to install homonimous package
+
 # 2.2.1
 * Added support for tinydata settings repo_name and repo_filename in tp::repo 
 * Added support for tinydata settings config_file_params and config_dir_params

--- a/lib/puppet/parser/functions/tp_lookup.rb
+++ b/lib/puppet/parser/functions/tp_lookup.rb
@@ -22,7 +22,10 @@ module Puppet::Parser::Functions
       hiera_file_path  = mp.path + '/data/' + app + '/hiera.yaml'
 
       unless File.exist?(hiera_file_path)
-        raise Puppet::ParseError, ("I can't find data for: #{app}. Looking in file: #{hiera_file_path}. Using this data module: #{datamodule}")
+        # raise Puppet::ParseError, ("I can't find data for: #{app}. Looking in file: #{hiera_file_path}. Using this data module: #{datamodule}")
+        function_warning(["No tinydata found for: #{app} in #{hiera_file_path}. Trying to install package #{app}"])
+        default_fallback = true
+        hiera_file_path  = mp.path + '/data/default/hiera.yaml'
       end
 
       hiera = YAML::load(File.open(hiera_file_path))
@@ -50,6 +53,8 @@ module Puppet::Parser::Functions
           end
         end
       }
+
+      value.merge!({'package_name' => app}) if default_fallback
 
     else
       raise(Puppet::ParseError, "Could not find module #{datamodule} in environment #{compiler.environment}")

--- a/lib/puppet/parser/functions/tp_lookup.rb
+++ b/lib/puppet/parser/functions/tp_lookup.rb
@@ -22,7 +22,6 @@ module Puppet::Parser::Functions
       hiera_file_path  = mp.path + '/data/' + app + '/hiera.yaml'
 
       unless File.exist?(hiera_file_path)
-        # raise Puppet::ParseError, ("I can't find data for: #{app}. Looking in file: #{hiera_file_path}. Using this data module: #{datamodule}")
         function_warning(["No tinydata found for: #{app} in #{hiera_file_path}. Trying to install package #{app}"])
         default_fallback = true
         hiera_file_path  = mp.path + '/data/default/hiera.yaml'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,6 @@
 class tp::params {
   $tp_path = $facts['os']['family'] ? {
     'windows' => 'C:/ProgramData/PuppetLabs/puppet/bin/tp',
-    'Darwin'  => '/usr/bin/tp',
     default   => '/usr/local/bin/tp',
   }
   $tp_dir = $facts['os']['family'] ? {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "example42-tp",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "summary": "Tiny Puppet",
   "license": "Apache-2.0",
   "author": "Alessandro Franceschi",
@@ -58,6 +58,7 @@
       "operatingsystemrelease": [
         "6",
         "7",
+        "8",
         "8"
       ]
     },
@@ -67,7 +68,8 @@
         "10.04",
         "12.04",
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {
@@ -87,6 +89,16 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "example42/tinydata",
+      "version_requirement": ">= 0.0.1 < 5.0.0"
+    }
+  ],
+  "optional_dependencies": [
+    {
+      "name": "puppetlabs/chocolatey",
+      "version_requirement": ">= 0.0.1 < 5.0.0"
     },
     {
       "name": "example42/tinydata",


### PR DESCRIPTION
… tinydata 0.3.0 or later for Darwin or Windows support

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

