### PR TITLE
Allow spaces in key for apt-key checks in tp::repo

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -185,7 +185,7 @@ define tp::repo (
         and !empty($settings[key_url]) {
           exec { "tp_aptkey_add_${settings[key]}":
             command => "wget -O - ${settings[key_url]} | apt-key add -",
-            unless  => "apt-key list | grep -q ${settings[key]}",
+            unless  => "apt-key list | grep -q \"${settings[key]}\"",
             path    => '/bin:/sbin:/usr/bin:/usr/sbin',
             before  => File["${aptrepo_title}.list"],
             user    => 'root',
@@ -198,7 +198,7 @@ define tp::repo (
         and !empty($settings[apt_key_server]) {
           exec { "tp_aptkey_adv_${settings[key]}":
             command => "apt-key adv --keyserver ${settings[apt_key_server]} --recv ${settings[apt_key_fingerprint]}",
-            unless  => "apt-key list | grep -q ${settings[key]}",
+            unless  => "apt-key list | grep -q \"${settings[key]}\"",
             path    => '/bin:/sbin:/usr/bin:/usr/sbin',
             before  => File["${aptrepo_title}.list"],
             user    => 'root',


### PR DESCRIPTION
## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

