### PR TITLE
 Documentation bug for config_file_notify/require

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ By default, configuration files managed by tp::conf automatically notify the ser
 You can also set custom resource references to point to actual resources you declare in your manifests:
 
     tp::conf { 'bind':
-      config_file_notify  => Service['bind9'],
-      config_file_require => Package['bind9-server'],
+      config_file_notify  => 'Service[bind9]',
+      config_file_require => 'Package[bind9-server]',
     }
 
 It's possible to manage files with different methods, for example directly providing its content:

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -105,8 +105,8 @@
 # @example to customise notify and require dependencies
 #
 #   tp::conf { 'nginx::nginx_fe.conf':
-#     config_file_notify  => "Service['fe_nginx']",
-#     config_file_require => "Class['site::fe::nginx']",
+#     config_file_notify  => 'Service[fe_nginx]',
+#     config_file_require => 'Class[site::fe::nginx]',
 #   }
 #
 # @example to disable validation for a configuration file


### PR DESCRIPTION
In the documentation the quoting was not correct.
