### PR TITLE
Fix for #68 for missing upstream_repo in tinydata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 2.4.1
+* Fix for tip::install when manage_repo is missing in tinydata
+
 # 2.4.0
 * Added manage_repo option
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -198,7 +198,7 @@ define tp::install (
   }
 
   # Automatic repo management
-  $use_upstream_repo = pick($upstream_repo,$settings[upstream_repo])
+  $use_upstream_repo = pick($upstream_repo,$settings[upstream_repo],false)
   if $use_upstream_repo or
   ( $auto_repo == true and ( $settings[repo_url] or $settings[yum_mirrorlist] or $settings[repo_package_url] ) ) {
     $repo_enabled = $ensure ? {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "example42-tp",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "summary": "Tiny Puppet",
   "license": "Apache-2.0",
   "author": "Example42 Gmbh",


### PR DESCRIPTION
#68 is due to not updated tinydata, here's a fix for backwards compatibility