### PR TITLE
#101 add default app=all to tp::test task

### DIFF
--- a/tasks/test.json
+++ b/tasks/test.json
@@ -4,7 +4,8 @@
   "parameters": {
     "app": {
       "description": "The application to test",
-      "type": "Optional[String[1]]"
+      "type": "Optional[String[1]]",
+      "default": "all"
     }
   }
 }


### PR DESCRIPTION
## Before submitting your PR

1.  No default app argument of 'all' for tp::test task
2.  Bug

## After submitting your PR

1.  Verify Travis checks and eventually fix the errors
2.  Feel free to ping us if we don't reply promptly 
