### PR TITLE
Feature/update legacy facts

### DIFF
--- a/lib/puppet/parser/functions/tp_lookup.rb
+++ b/lib/puppet/parser/functions/tp_lookup.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
     value = { }
 
     if mp = Puppet::Module.find(datamodule, compiler.environment.to_s)
-      
+
       hiera_file_path  = mp.path + '/data/' + app + '/hiera.yaml'
 
       unless File.exist?(hiera_file_path)
@@ -39,13 +39,13 @@ module Puppet::Parser::Functions
 
       model = {
         :title                     => app,
-        :osfamily                  => lookupvar("::osfamily"),
-        :operatingsystem           => lookupvar("::operatingsystem"),
-        :operatingsystemmajrelease => lookupvar("::operatingsystemmajrelease"),
-        :operatingsystemrelease    => lookupvar("::operatingsystemrelease"),
+        :osfamily                  => Facter.value('os')['family'],
+        :operatingsystem           => Facter.value('os')['name'],
+        :operatingsystemmajrelease => Facter.value('os')['release']['major'],
+        :operatingsystemrelease    => Facter.value('os')['release']['full'],
         :repo                      => repo,
       }
-       
+
       hiera[:hierarchy].reverse!.each { | p |
         conf_file_path = mp.path + '/data/' + p % model + '.yaml'
 

--- a/lib/puppet/parser/functions/tp_lookup.rb
+++ b/lib/puppet/parser/functions/tp_lookup.rb
@@ -37,13 +37,15 @@ module Puppet::Parser::Functions
         repo = ''
       end
 
+      os = lookupvar("::os")
+
       model = {
-        :title                     => app,
-        :osfamily                  => Facter.value('os')['family'],
-        :operatingsystem           => Facter.value('os')['name'],
-        :operatingsystemmajrelease => Facter.value('os')['release']['major'],
-        :operatingsystemrelease    => Facter.value('os')['release']['full'],
-        :repo                      => repo,
+        :title => app,
+        :osfamily => os['family'],
+        :operatingsystem => os['name'],
+        :operatingsystemmajrelease => os['release']['major'],
+        :operatingsystemrelease => os['release']['full'],
+        :repo => repo,
       }
 
       hiera[:hierarchy].reverse!.each { | p |

--- a/lib/puppet/parser/functions/tp_lookup4.rb
+++ b/lib/puppet/parser/functions/tp_lookup4.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
     value = { }
 
     if mp = Puppet::Module.find(datamodule, compiler.environment.to_s)
-      
+
       hiera_file_path  = mp.path + '/data/' + app + '/hiera.yaml'
 
       unless File.exist?(hiera_file_path)
@@ -39,13 +39,13 @@ module Puppet::Parser::Functions
 
       model = {
         :title                     => app,
-        :osfamily                  => lookupvar("::osfamily"),
-        :operatingsystem           => lookupvar("::operatingsystem"),
-        :operatingsystemmajrelease => lookupvar("::operatingsystemmajrelease"),
-        :operatingsystemrelease    => lookupvar("::operatingsystemrelease"),
+        :osfamily                  => Facter.value('os')['family'],
+        :operatingsystem           => Facter.value('os')['name'],
+        :operatingsystemmajrelease => Facter.value('os')['release']['major'],
+        :operatingsystemrelease    => Facter.value('os')['release']['full'],
         :repo                      => repo,
       }
-       
+
       hiera[:hierarchy].reverse!.each { | p |
         conf_file_path = mp.path + '/data/' + p % model + '.yaml'
 

--- a/lib/puppet/parser/functions/tp_lookup4.rb
+++ b/lib/puppet/parser/functions/tp_lookup4.rb
@@ -37,13 +37,15 @@ module Puppet::Parser::Functions
         repo = ''
       end
 
+      os = lookupvar("::os")
+
       model = {
-        :title                     => app,
-        :osfamily                  => Facter.value('os')['family'],
-        :operatingsystem           => Facter.value('os')['name'],
-        :operatingsystemmajrelease => Facter.value('os')['release']['major'],
-        :operatingsystemrelease    => Facter.value('os')['release']['full'],
-        :repo                      => repo,
+        :title => app,
+        :osfamily => os['family'],
+        :operatingsystem => os['name'],
+        :operatingsystemmajrelease => os['release']['major'],
+        :operatingsystemrelease => os['release']['full'],
+        :repo => repo,
       }
 
       hiera[:hierarchy].reverse!.each { | p |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,7 +129,7 @@ class tp (
     deprecation('options_hash', 'Replace with options')
   }
 
-  if has_key($facts,'identity') {
+  if 'identity' in $facts {
     $real_tp_params = $facts['identity']['privileged'] ? {
       false   => $tp_params['user'],
       default => $tp_params['global'],
@@ -244,7 +244,7 @@ class tp (
     }
 
     # Cli dirs and files
-    if has_key($facts,'identity') {
+    if 'identity' in $facts {
       $real_cli_enable = $facts['identity']['privileged'] ? {
         false   => false,
         default => $cli_enable,
@@ -390,7 +390,7 @@ class tp (
     }
     $osfamily_install_hash_merged.each |$k,$v| {
       if $facts['os']['family'] == $k {
-        if has_key($osfamily_install_defaults, $k) {
+        if $k in $osfamily_install_defaults {
           $os_defaults = $osfamily_install_defaults[$k]
         } else {
           $os_defaults = {}
@@ -433,7 +433,7 @@ class tp (
     }
     $osfamily_conf_hash_merged.each |$k,$v| {
       if $facts['os']['family'] == $k {
-        if has_key($osfamily_conf_defaults, $k) {
+        if $k in $osfamily_conf_defaults {
           $os_defaults = $osfamily_conf_defaults[$k]
         } else {
           $os_defaults = {}


### PR DESCRIPTION
This fixes has_key error when use stdlib>=9.x.y
Replaces legacy facts so Puppet 8 can handle it